### PR TITLE
:fix: Change unsecure commands to legal on github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Install poetry
       run: |
         curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-        echo "::add-path::$HOME/.poetry/bin"
+        echo "$HOME/.poetry/bin" >> $GITHUB_PATH
 
     - name: Install package
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install poetry
       run: |
         curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-        echo "::set-env name=PATH::$HOME/.poetry/bin:$PATH"
+        echo "$HOME/.poetry/bin" >> $GITHUB_PATH
 
     - name: Install package
       run: |


### PR DESCRIPTION
see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
and https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files