### PR TITLE
Setting stdout to utf8 encoding

### DIFF
--- a/investments/ibtax/ibtax.py
+++ b/investments/ibtax/ibtax.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
 import os
+import sys
 from typing import Iterable, List, Optional
 
 import pandas  # type: ignore
@@ -270,6 +271,8 @@ def parse_reports(activity_reports_dir: str, confirmation_reports_dir: str) -> I
 
 
 def main():
+    sys.stdout.reconfigure(encoding='utf-8')
+
     parser = argparse.ArgumentParser()
     parser.add_argument('--activity-reports-dir', type=str, required=True, help='directory with InteractiveBrokers .csv activity reports')
     parser.add_argument('--confirmation-reports-dir', type=str, required=True, help='directory with InteractiveBrokers .csv confirmation reports')


### PR DESCRIPTION
Устраняет ошибку при перенаправления вывода в файл. По крайней мере на Windows перенаправление в файл не работает из-за наличия юникодных символов (символ рубля нрапример). Возникает ошибка: 

`UnicodeEncodeError: 'charmap' codec can't encode character '\u20bd' in position 232: character maps to <undefined>`