### PR TITLE
Handle datetime format with semicolon

### DIFF
--- a/investments/report_parsers/ib.py
+++ b/investments/report_parsers/ib.py
@@ -16,7 +16,7 @@ from investments.deposit import Deposit
 
 
 def _parse_datetime(strval: str) -> datetime.datetime:
-    return datetime.datetime.strptime(strval.replace(' ', ''), '%Y-%m-%d,%H:%M:%S')
+    return datetime.datetime.strptime(strval.replace(' ', '').replace(';',','), '%Y-%m-%d,%H:%M:%S')
 
 
 def _parse_date(strval: str) -> datetime.date:


### PR DESCRIPTION
Sometimes the datetime in the Interactive Broker reports is written as "%Y-%m-%d;%H:%M:%S", as well as "%Y-%m-%d,%H:%M:%S". In this commit the semicolon in the string is replaced by a comma, so that the parser could handle both cases.